### PR TITLE
Strip underscores from parameter names

### DIFF
--- a/lastfmclient/client.py
+++ b/lastfmclient/client.py
@@ -87,7 +87,7 @@ class LastfmClient(BaseClient):
         }
 
         params.update(defaults)
-        params = {k: v for k, v in params.items()
+        params = {k.rstrip('_'): v for k, v in params.items()
                   if v is not None and k != 'callback'}
 
         getting_session = method == 'auth.getSession'


### PR DESCRIPTION
An underscore was added to pass some parameters of Last.fm methods as Python keywords, e.g. 'from'. This way it won't be confused with reserved word 'from'.
